### PR TITLE
Use supported Codex model

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -35,7 +35,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.5-codex/xhigh
+          model: gpt-5.4/xhigh
           resume: true
           prompt: |
             Goals:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -35,7 +35,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.3-codex/xhigh
+          model: gpt-5.5-codex/xhigh
           resume: true
           prompt: |
             Goals:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.5-codex/xhigh
+          model: gpt-5.4/xhigh
           prompt: |
             Goal: on every push to main, move v{major} to the current commit. If package.json version changed, create v{version} and a GitHub release for it.
 

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
+          model: gpt-5.5-codex/xhigh
           prompt: |
             Goal: on every push to main, move v{major} to the current commit. If package.json version changed, create v{version} and a GitHub release for it.
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,7 +25,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.3-codex/xhigh
+          model: gpt-5.5-codex/xhigh
           resume: true
           prompt: |
             Goal: keep the root package.json version aligned with the impact of changes in this repo.

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,7 +25,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.5-codex/xhigh
+          model: gpt-5.4/xhigh
           resume: true
           prompt: |
             Goal: keep the root package.json version aligned with the impact of changes in this repo.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This makes iterative work practical: the agent remembers what it already covered
 | `agent_auth_file` | no | Agent auth file content (agent-specific). |
 | `github_token` | no | GitHub token used by the action (defaults to the workflow token). |
 | `github_token_actor` | no | Actor login for `github_token` when using a non-workflow token (e.g. `sudden-agent[bot]`). |
-| `model` | no | Agent model override (for Codex, append reasoning effort with /, e.g. `gpt-5.3-codex/xhigh`) |
+| `model` | no | Agent model override (for Codex, append reasoning effort with /, e.g. `gpt-5.5-codex/xhigh`) |
 | `prompt` | no | Additional instructions for the agent. |
 | `resume` | no | Enable session persistence. Default: `false`. |
 | `sudo` | no | Disable sandbox; allow write + network access. Default: `false`. |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This makes iterative work practical: the agent remembers what it already covered
 | `agent_auth_file` | no | Agent auth file content (agent-specific). |
 | `github_token` | no | GitHub token used by the action (defaults to the workflow token). |
 | `github_token_actor` | no | Actor login for `github_token` when using a non-workflow token (e.g. `sudden-agent[bot]`). |
-| `model` | no | Agent model override (for Codex, append reasoning effort with /, e.g. `gpt-5.5-codex/xhigh`) |
+| `model` | no | Agent model override (for Codex, append reasoning effort with /, e.g. `gpt-5.4/xhigh`) |
 | `prompt` | no | Additional instructions for the agent. |
 | `resume` | no | Enable session persistence. Default: `false`. |
 | `sudo` | no | Disable sandbox; allow write + network access. Default: `false`. |

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
     default: codex
   model:
-    description: Agent model override (for Codex, append reasoning effort with /, e.g. gpt-5.2-codex/xhigh)
+    description: Agent model override (for Codex, append reasoning effort with /, e.g. gpt-5.5-codex/xhigh)
     required: false
     default: ""
   prompt:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
     default: codex
   model:
-    description: Agent model override (for Codex, append reasoning effort with /, e.g. gpt-5.5-codex/xhigh)
+    description: Agent model override (for Codex, append reasoning effort with /, e.g. gpt-5.4/xhigh)
     required: false
     default: ""
   prompt:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sudden-agent",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sudden-agent",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "dependencies": {
         "@actions/artifact": "^2.2.0",
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sudden-agent",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.11.2",
   "main": "dist/index.js",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/src/agents/codex/codex.test.ts
+++ b/src/agents/codex/codex.test.ts
@@ -26,26 +26,26 @@ describe('agent codex', () => {
     });
 
     it('parses model only', () => {
-      expect(parseModelInput('gpt-5.3-codex')).toEqual({ model: 'gpt-5.3-codex', reasoningEffort: undefined });
+      expect(parseModelInput('gpt-5.5-codex')).toEqual({ model: 'gpt-5.5-codex', reasoningEffort: undefined });
     });
 
     it('parses model and reasoning effort', () => {
-      expect(parseModelInput('gpt-5.3-codex/xhigh')).toEqual({
-        model: 'gpt-5.3-codex',
+      expect(parseModelInput('gpt-5.5-codex/xhigh')).toEqual({
+        model: 'gpt-5.5-codex',
         reasoningEffort: 'xhigh',
       });
     });
 
     it('trims whitespace', () => {
-      expect(parseModelInput(' gpt-5.3-codex / high ')).toEqual({
-        model: 'gpt-5.3-codex',
+      expect(parseModelInput(' gpt-5.5-codex / high ')).toEqual({
+        model: 'gpt-5.5-codex',
         reasoningEffort: 'high',
       });
     });
 
     it('handles empty model or effort', () => {
       expect(parseModelInput('/high')).toEqual({ model: undefined, reasoningEffort: 'high' });
-      expect(parseModelInput('gpt-5.3-codex/')).toEqual({ model: 'gpt-5.3-codex', reasoningEffort: undefined });
+      expect(parseModelInput('gpt-5.5-codex/')).toEqual({ model: 'gpt-5.5-codex', reasoningEffort: undefined });
     });
   });
 

--- a/src/agents/codex/codex.test.ts
+++ b/src/agents/codex/codex.test.ts
@@ -26,26 +26,26 @@ describe('agent codex', () => {
     });
 
     it('parses model only', () => {
-      expect(parseModelInput('gpt-5.5-codex')).toEqual({ model: 'gpt-5.5-codex', reasoningEffort: undefined });
+      expect(parseModelInput('gpt-5.4')).toEqual({ model: 'gpt-5.4', reasoningEffort: undefined });
     });
 
     it('parses model and reasoning effort', () => {
-      expect(parseModelInput('gpt-5.5-codex/xhigh')).toEqual({
-        model: 'gpt-5.5-codex',
+      expect(parseModelInput('gpt-5.4/xhigh')).toEqual({
+        model: 'gpt-5.4',
         reasoningEffort: 'xhigh',
       });
     });
 
     it('trims whitespace', () => {
-      expect(parseModelInput(' gpt-5.5-codex / high ')).toEqual({
-        model: 'gpt-5.5-codex',
+      expect(parseModelInput(' gpt-5.4 / high ')).toEqual({
+        model: 'gpt-5.4',
         reasoningEffort: 'high',
       });
     });
 
     it('handles empty model or effort', () => {
       expect(parseModelInput('/high')).toEqual({ model: undefined, reasoningEffort: 'high' });
-      expect(parseModelInput('gpt-5.5-codex/')).toEqual({ model: 'gpt-5.5-codex', reasoningEffort: undefined });
+      expect(parseModelInput('gpt-5.4/')).toEqual({ model: 'gpt-5.4', reasoningEffort: undefined });
     });
   });
 


### PR DESCRIPTION
## Summary
- use gpt-5.4/xhigh in agent workflows
- add explicit model to tag-and-release
- update docs and parser test examples

## Notes
- @openai/codex@0.98.0 accepts gpt-5.4
- gpt-5.5 requires newer Codex CLI

## Tests
- pinned @openai/codex@0.98.0 smoke-tested with gpt-5.4