### PR TITLE
Test auth writeback from develop action

### DIFF
--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -1,0 +1,34 @@
+name: test-bench
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+jobs:
+  test-auth-writeback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Force auth write-back from develop
+        uses: sudden-network/agent@develop
+        with:
+          agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
+          agent_auth_file_secret_name: CODEX_AUTH_JSON
+          model: gpt-5.4/xhigh
+          sudo: true
+          prompt: |
+            Force the auth secret write-back path.
+
+            Run a local command that reads `~/.codex/auth.json`, parses it as JSON, and writes the same object back
+            using `JSON.stringify(value, null, 2) + "\n"`.
+
+            Do not print the auth file contents. Do not modify repository files. Do not post comments.

--- a/.github/workflows/test-bench.yml
+++ b/.github/workflows/test-bench.yml
@@ -28,7 +28,7 @@ jobs:
           prompt: |
             Force the auth secret write-back path.
 
-            Run a local command that reads `~/.codex/auth.json`, parses it as JSON, and writes the same object back
-            using `JSON.stringify(value, null, 2) + "\n"`.
+            Run a local command that reads `~/.codex/auth.json`, parses it as JSON, and writes the same top-level keys
+            back in reverse order using `JSON.stringify(value, null, 2) + "\n"`.
 
             Do not print the auth file contents. Do not modify repository files. Do not post comments.


### PR DESCRIPTION
Temporary test bench to force sudden-network/agent@develop auth write-back.