### PR TITLE
Support Codex 5.5 fast mode

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -35,7 +35,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.4/xhigh
+          model: gpt-5.5/xhigh/fast
           resume: true
           prompt: |
             Goals:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.4/xhigh
+          model: gpt-5.5/xhigh/fast
           prompt: |
             Goal: on every push to main, move v{major} to the current commit. If package.json version changed, create v{version} and a GitHub release for it.
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,7 +25,7 @@ jobs:
         uses: sudden-network/agent@v1
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.4/xhigh
+          model: gpt-5.5/xhigh/fast
           resume: true
           prompt: |
             Goal: keep the root package.json version aligned with the impact of changes in this repo.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This makes iterative work practical: the agent remembers what it already covered
 | `agent_auth_file_secret_name` | no | GitHub Actions secret name to update when the agent auth file refreshes. |
 | `github_token` | no | GitHub token used by the action (defaults to the workflow token). |
 | `github_token_actor` | no | Actor login for `github_token` when using a non-workflow token (e.g. `sudden-agent[bot]`). |
-| `model` | no | Agent model override (for Codex, append reasoning effort with /, e.g. `gpt-5.4/xhigh`) |
+| `model` | no | Agent model override (for Codex, append reasoning effort and service tier with `/`, e.g. `gpt-5.5/xhigh/fast`). |
 | `prompt` | no | Additional instructions for the agent. |
 | `resume` | no | Enable session persistence. Default: `false`. |
 | `sudo` | no | Disable sandbox; allow write + network access. Default: `false`. |

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     required: false
     default: codex
   model:
-    description: Agent model override (for Codex, append reasoning effort with /, e.g. gpt-5.4/xhigh)
+    description: Agent model override (for Codex, append reasoning effort and service tier with /, e.g. gpt-5.5/xhigh/fast)
     required: false
     default: ""
   prompt:

--- a/src/agents/codex/codex.run.test.ts
+++ b/src/agents/codex/codex.run.test.ts
@@ -43,4 +43,17 @@ describe('codex run', () => {
     const options = runCommandMock.mock.calls[0][2];
     expect(options.env).toBeUndefined();
   });
+
+  it('passes model config', async () => {
+    inputsMock.model = 'gpt-5.5/xhigh/fast';
+
+    await run('prompt');
+
+    const args = runCommandMock.mock.calls[0][1];
+    expect(args).toEqual(expect.arrayContaining([
+      '--model=gpt-5.5',
+      '--config=model_reasoning_effort=xhigh',
+      '--config=service_tier=fast',
+    ]));
+  });
 });

--- a/src/agents/codex/codex.test.ts
+++ b/src/agents/codex/codex.test.ts
@@ -32,26 +32,57 @@ describe('agent codex', () => {
     });
 
     it('parses model only', () => {
-      expect(parseModelInput('gpt-5.4')).toEqual({ model: 'gpt-5.4', reasoningEffort: undefined });
+      expect(parseModelInput('test-model')).toEqual({
+        model: 'test-model',
+        reasoningEffort: undefined,
+        serviceTier: undefined,
+      });
     });
 
     it('parses model and reasoning effort', () => {
-      expect(parseModelInput('gpt-5.4/xhigh')).toEqual({
-        model: 'gpt-5.4',
+      expect(parseModelInput('test-model/xhigh')).toEqual({
+        model: 'test-model',
         reasoningEffort: 'xhigh',
+        serviceTier: undefined,
+      });
+    });
+
+    it('parses model, reasoning effort, and service tier', () => {
+      expect(parseModelInput('gpt-5.5/xhigh/fast')).toEqual({
+        model: 'gpt-5.5',
+        reasoningEffort: 'xhigh',
+        serviceTier: 'fast',
       });
     });
 
     it('trims whitespace', () => {
-      expect(parseModelInput(' gpt-5.4 / high ')).toEqual({
-        model: 'gpt-5.4',
+      expect(parseModelInput(' test-model / high / fast ')).toEqual({
+        model: 'test-model',
         reasoningEffort: 'high',
+        serviceTier: 'fast',
       });
     });
 
     it('handles empty model or effort', () => {
-      expect(parseModelInput('/high')).toEqual({ model: undefined, reasoningEffort: 'high' });
-      expect(parseModelInput('gpt-5.4/')).toEqual({ model: 'gpt-5.4', reasoningEffort: undefined });
+      expect(parseModelInput('/high')).toEqual({
+        model: undefined,
+        reasoningEffort: 'high',
+        serviceTier: undefined,
+      });
+      expect(parseModelInput('test-model/')).toEqual({
+        model: 'test-model',
+        reasoningEffort: undefined,
+        serviceTier: undefined,
+      });
+    });
+
+    it('throws when service tier skips reasoning effort', () => {
+      expect(() => parseModelInput('gpt-5.5//fast')).toThrow(
+        'Invalid model input: service tier requires reasoning effort.',
+      );
+      expect(() => parseModelInput('gpt-5.5/ /fast')).toThrow(
+        'Invalid model input: service tier requires reasoning effort.',
+      );
     });
   });
 

--- a/src/agents/codex/codex.ts
+++ b/src/agents/codex/codex.ts
@@ -16,7 +16,7 @@ type AuthStrategy =
   | { kind: 'api_key'; apiKey: string }
   | { kind: 'auth_file'; authFile: string };
 
-const CODEX_VERSION = '0.98.0';
+const CODEX_VERSION = '0.136.0';
 const CODEX_DIR = path.join(os.homedir(), '.codex');
 const CODEX_CONFIG_PATH = path.join(CODEX_DIR, 'config.toml');
 const CODEX_AUTH_PATH = path.join(CODEX_DIR, 'auth.json');
@@ -140,10 +140,16 @@ const persistAuthFileSecret = async () => {
 
 export const parseModelInput = (value: string | undefined) => {
   if (!value) return {};
-  const [model, reasoningEffort] = value.split('/', 2).map((part) => part.trim());
+  const [model, reasoningEffort, serviceTier] = value.split('/').map((part) => part.trim());
+
+  if (serviceTier && !reasoningEffort) {
+    throw new Error('Invalid model input: service tier requires reasoning effort.');
+  }
+
   return {
     model: model || undefined,
     reasoningEffort: reasoningEffort || undefined,
+    serviceTier: serviceTier || undefined,
   };
 };
 
@@ -166,7 +172,7 @@ export const teardown = async () => {
 };
 
 export const run = async (prompt: string) => {
-  const { model, reasoningEffort } = parseModelInput(inputs.model);
+  const { model, reasoningEffort, serviceTier } = parseModelInput(inputs.model);
   const sandbox = inputs.sudo ? 'danger-full-access' : 'read-only';
   const execOptions: ExecOptions = { input: Buffer.from(prompt, 'utf8') };
 
@@ -181,6 +187,7 @@ export const run = async (prompt: string) => {
       `--sandbox=${sandbox}`,
       ...(model ? [`--model=${model}`] : []),
       ...(reasoningEffort ? [`--config=model_reasoning_effort=${reasoningEffort}`] : []),
+      ...(serviceTier ? [`--config=service_tier=${serviceTier}`] : []),
       '-',
       'resume',
       '--last',


### PR DESCRIPTION
Updates Codex CLI to 0.136.0, adds service tier parsing via model/reasoning/tier, and switches agent workflows/docs to gpt-5.5/xhigh/fast.\n\nValidation:\n- npm test -- codex\n- npm run build\n- npm test\n- git diff --check