### PR TITLE
Add Codex auth bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Group all constants at the top of the module or scope, but only when reused; inline single-use values and one-off helper consts.
 - If a value is used once (e.g., base objects for spreads), inline it unless reuse is needed.
 - Avoid duplication and keep sources of truth single to reduce maintenance overhead.
+- When updating the Codex CLI version, update both `CODEX_VERSION` in `src/agents/codex/codex.ts` and `scripts/bootstrap-codex-auth.sh`.
 - Avoid defensive code; write only what requirements or evidence justify.
 - Avoid scope creep; no extra changes or state tweaks unless required or asked.
 - When changing behavior, check for existing tests covering it; add or update tests to cover the new behavior if missing.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ For the default agent (`codex`), `agent_auth_file` can be used to inject Codex's
 
 Set `agent_auth_file_secret_name` with `agent_auth_file` to update the repository secret after Codex refreshes `auth.json`. `agent_auth_file_secret_name` can only be used with a [GitHub App token](github-app/README.md) configured with `permission-secrets: write`.
 
+Use a separate Codex auth file for this GitHub Actions secret. If you keep using the same copied `auth.json` locally, local refreshes can invalidate the secret. Running `codex logout` with that auth file revokes its refresh token.
+
+To create a separate Codex auth file locally without touching your normal `~/.codex` login:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sudden-network/agent/main/scripts/bootstrap-codex-auth.sh | bash
+```
+
+The script runs Codex browser login in a fresh temporary `CODEX_HOME`, copies the resulting `auth.json` to your clipboard, and removes the temporary directory. Paste the clipboard into the `CODEX_AUTH_JSON` GitHub Actions secret. Run it once per repo or org secret; do not reuse one generated `auth.json` across repos or orgs.
+
 ## Permissions
 
 This action relies on the workflow `GITHUB_TOKEN`.

--- a/dist/index.js
+++ b/dist/index.js
@@ -90428,15 +90428,14 @@ const shouldResume = () => {
         return false;
     return Boolean(github_1.context.payload.issue || github_1.context.payload.pull_request);
 };
-const buildConfig = (mcpServers) => {
-    return mcpServers
-        .map(({ name, url }) => [
+const buildConfig = (mcpServers) => [
+    'cli_auth_credentials_store = "file"',
+    ...mcpServers.map(({ name, url }) => [
         `[mcp_servers.${name}]`,
         `url = "${url}"`,
         'default_tools_approval_mode = "approve"',
-    ].join('\n'))
-        .join('\n\n');
-};
+    ].join('\n')),
+].join('\n\n');
 exports.buildConfig = buildConfig;
 const writeCodexConfig = (mcpServers) => {
     ensureDir(CODEX_DIR);
@@ -90532,8 +90531,10 @@ const persistAuthFileSecret = async () => {
         return;
     if (!secretName)
         return;
-    if (!fs_1.default.existsSync(CODEX_AUTH_PATH))
+    if (!fs_1.default.existsSync(CODEX_AUTH_PATH)) {
+        (0, core_1.warning)(`Cannot update ${secretName} auth file secret: ${CODEX_AUTH_PATH} does not exist.`);
         return;
+    }
     const update = (0, exports.getAuthFileSecretUpdate)(auth.authFile, secretName, fs_1.default.readFileSync(CODEX_AUTH_PATH, 'utf8'));
     if (!update)
         return;

--- a/github-app/README.md
+++ b/github-app/README.md
@@ -51,3 +51,13 @@ Use org-level settings for reuse across repos, or repo-level settings for a sing
     github_token_actor: ${{ steps.app_token.outputs.app-slug }}[bot]
     ...
 ```
+
+Use a separate Codex `auth.json` for this GitHub Actions secret. Running `codex logout` with the same file revokes its refresh token and invalidates `CODEX_AUTH_JSON`.
+
+Create that separate file locally without touching your normal `~/.codex` login:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sudden-network/agent/main/scripts/bootstrap-codex-auth.sh | bash
+```
+
+The script uses Codex browser login with a fresh temporary `CODEX_HOME`. Paste the copied `auth.json` into the `CODEX_AUTH_JSON` GitHub Actions secret. Run it once per repo or org secret; do not reuse one generated `auth.json` across repos or orgs.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sudden-agent",
   "private": true,
   "packageManager": "pnpm@11.5.3",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "main": "dist/index.js",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/scripts/bootstrap-codex-auth.sh
+++ b/scripts/bootstrap-codex-auth.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODEX_VERSION="0.136.0"
+CODEX_HOME_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$CODEX_HOME_DIR"
+}
+trap cleanup EXIT
+
+export CODEX_HOME="$CODEX_HOME_DIR"
+
+cat > "$CODEX_HOME/config.toml" <<'EOF'
+cli_auth_credentials_store = "file"
+forced_login_method = "chatgpt"
+EOF
+
+echo "Using temporary CODEX_HOME: $CODEX_HOME"
+echo "This does not touch ~/.codex/auth.json."
+echo "Opening browser for Codex ChatGPT login."
+
+npx --yes "@openai/codex@${CODEX_VERSION}" login
+
+pbcopy < "$CODEX_HOME/auth.json"
+
+echo "Copied Codex auth.json to clipboard."
+echo "Paste it into the CODEX_AUTH_JSON GitHub Actions secret."
+echo "Run this once per repo or org secret. Do not reuse this auth.json across repos or orgs."

--- a/src/agents/codex/codex.test.ts
+++ b/src/agents/codex/codex.test.ts
@@ -17,6 +17,8 @@ describe('agent codex', () => {
 
       expect(config).toBe(
         [
+          'cli_auth_credentials_store = "file"',
+          '',
           '[mcp_servers.github]',
           'url = "http://localhost:1234/mcp"',
           'default_tools_approval_mode = "approve"',

--- a/src/agents/codex/codex.ts
+++ b/src/agents/codex/codex.ts
@@ -29,15 +29,14 @@ const shouldResume = (): boolean => {
   return Boolean(context.payload.issue || context.payload.pull_request);
 };
 
-export const buildConfig = (mcpServers: McpServerConfig[]) => {
-  return mcpServers
-    .map(({ name, url }) => [
-      `[mcp_servers.${name}]`,
-      `url = "${url}"`,
-      'default_tools_approval_mode = "approve"',
-    ].join('\n'))
-    .join('\n\n');
-};
+export const buildConfig = (mcpServers: McpServerConfig[]) => [
+  'cli_auth_credentials_store = "file"',
+  ...mcpServers.map(({ name, url }) => [
+    `[mcp_servers.${name}]`,
+    `url = "${url}"`,
+    'default_tools_approval_mode = "approve"',
+  ].join('\n')),
+].join('\n\n');
 
 const writeCodexConfig = (mcpServers: McpServerConfig[]) => {
   ensureDir(CODEX_DIR);
@@ -138,7 +137,10 @@ const persistAuthFileSecret = async () => {
 
   if (auth.kind !== 'auth_file') return;
   if (!secretName) return;
-  if (!fs.existsSync(CODEX_AUTH_PATH)) return;
+  if (!fs.existsSync(CODEX_AUTH_PATH)) {
+    warning(`Cannot update ${secretName} auth file secret: ${CODEX_AUTH_PATH} does not exist.`);
+    return;
+  }
 
   const update = getAuthFileSecretUpdate(
     auth.authFile,


### PR DESCRIPTION
## Summary
- force Codex auth storage to file for auth-file runs
- add local browser-login bootstrap script for dedicated CODEX_AUTH_JSON secrets
- document dedicated per repo/org auth files and logout/reuse caveats

## Tests
- pnpm build
- pnpm test
- bash -n scripts/bootstrap-codex-auth.sh
- git diff --check