### PR TITLE
Support CODEX_AUTH_JSON secret updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,29 +55,7 @@ Treat `agent_auth_file` like a password (it grants access to the underlying agen
 
 For the default agent (`codex`), `agent_auth_file` can be used to inject Codex's `auth.json` (from `~/.codex/auth.json`) so the CLI can use a ChatGPT subscription.
 
-Auth file refresh works like this:
-
-- The workflow passes `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`.
-- The action writes that value to Codex's `~/.codex/auth.json`.
-- Codex may refresh `auth.json` during the run.
-- After the run, the action updates the existing `CODEX_AUTH_JSON` repository or organization secret when `auth.json` changed.
-
-Requirements for refresh writeback:
-
-- The workflow must pass `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`. GitHub does not let actions read secret values by name.
-- `CODEX_AUTH_JSON` must already exist as a repository secret or an organization secret shared with the repository.
-- `github_token` must be a [GitHub App token](github-app/README.md) with `permission-secrets: write`; the default `GITHUB_TOKEN` cannot update secrets.
-- Organization secret writeback requires the GitHub App to have the organization `secrets: write` permission.
-
-Use a separate Codex auth file for this GitHub Actions secret. If you keep using the same copied `auth.json` locally, local refreshes can invalidate the secret. Running `codex logout` with that auth file revokes its refresh token.
-
-To create a separate Codex auth file locally without touching your normal `~/.codex` login:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/sudden-network/agent/main/scripts/bootstrap-codex-auth.sh | bash
-```
-
-The script runs Codex browser login in a fresh temporary `CODEX_HOME`, copies the resulting `auth.json` to your clipboard, and removes the temporary directory. Paste the clipboard into the `CODEX_AUTH_JSON` GitHub Actions secret. Run it once per repo or org secret; do not reuse one generated `auth.json` across repos or orgs.
+To use Codex with a ChatGPT subscription in GitHub Actions, store a dedicated `CODEX_AUTH_JSON` secret and use a [GitHub App token](github-app/README.md) so the action can save the updated Codex login after each run. See the [GitHub App setup](github-app/README.md) for the workflow setup and bootstrap command.
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This makes iterative work practical: the agent remembers what it already covered
 | `agent` | no | Agent to run (`codex` default). |
 | `agent_api_key` | no | Agent API key. Required unless `agent_auth_file` is set. |
 | `agent_auth_file` | no | Agent auth file content (agent-specific). |
-| `agent_auth_file_secret_name` | no | GitHub Actions secret name to update when the agent auth file refreshes. |
 | `github_token` | no | GitHub token used by the action (defaults to the workflow token). |
 | `github_token_actor` | no | Actor login for `github_token` when using a non-workflow token (e.g. `sudden-agent[bot]`). |
 | `model` | no | Agent model override (for Codex, append reasoning effort and service tier with `/`, e.g. `gpt-5.5/xhigh/fast`). |
@@ -56,20 +55,19 @@ Treat `agent_auth_file` like a password (it grants access to the underlying agen
 
 For the default agent (`codex`), `agent_auth_file` can be used to inject Codex's `auth.json` (from `~/.codex/auth.json`) so the CLI can use a ChatGPT subscription.
 
-Set `agent_auth_file_secret_name` with `agent_auth_file` to update the repository secret after Codex refreshes `auth.json`. `agent_auth_file_secret_name` can only be used with a [GitHub App token](github-app/README.md) configured with `permission-secrets: write`.
-
 Auth file refresh works like this:
 
 - The workflow passes `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`.
 - The action writes that value to Codex's `~/.codex/auth.json`.
 - Codex may refresh `auth.json` during the run.
-- After the run, the action updates the repository secret named by `agent_auth_file_secret_name` when `auth.json` changed.
+- After the run, the action updates the existing `CODEX_AUTH_JSON` repository or organization secret when `auth.json` changed.
 
 Requirements for refresh writeback:
 
-- `agent_auth_file_secret_name` must be set to the secret name, for example `CODEX_AUTH_JSON`.
-- `github_token` must be a GitHub App token with `permission-secrets: write`; the default `GITHUB_TOKEN` cannot update secrets.
-- The secret is written back as a repository secret. If the run initially reads an organization secret, writeback creates or updates a repository secret with the same name for that repository.
+- The workflow must pass `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`. GitHub does not let actions read secret values by name.
+- `CODEX_AUTH_JSON` must already exist as a repository secret or an organization secret shared with the repository.
+- `github_token` must be a [GitHub App token](github-app/README.md) with `permission-secrets: write`; the default `GITHUB_TOKEN` cannot update secrets.
+- Organization secret writeback requires the GitHub App to have the organization `secrets: write` permission.
 
 Use a separate Codex auth file for this GitHub Actions secret. If you keep using the same copied `auth.json` locally, local refreshes can invalidate the secret. Running `codex logout` with that auth file revokes its refresh token.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ For the default agent (`codex`), `agent_auth_file` can be used to inject Codex's
 
 Set `agent_auth_file_secret_name` with `agent_auth_file` to update the repository secret after Codex refreshes `auth.json`. `agent_auth_file_secret_name` can only be used with a [GitHub App token](github-app/README.md) configured with `permission-secrets: write`.
 
+Auth file refresh works like this:
+
+- The workflow passes `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`.
+- The action writes that value to Codex's `~/.codex/auth.json`.
+- Codex may refresh `auth.json` during the run.
+- After the run, the action updates the repository secret named by `agent_auth_file_secret_name` when `auth.json` changed.
+
+Requirements for refresh writeback:
+
+- `agent_auth_file_secret_name` must be set to the secret name, for example `CODEX_AUTH_JSON`.
+- `github_token` must be a GitHub App token with `permission-secrets: write`; the default `GITHUB_TOKEN` cannot update secrets.
+- The secret is written back as a repository secret. If the run initially reads an organization secret, writeback creates or updates a repository secret with the same name for that repository.
+
 Use a separate Codex auth file for this GitHub Actions secret. If you keep using the same copied `auth.json` locally, local refreshes can invalidate the secret. Running `codex logout` with that auth file revokes its refresh token.
 
 To create a separate Codex auth file locally without touching your normal `~/.codex` login:

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,6 @@ inputs:
     description: Agent auth file content (agent-specific)
     required: false
     default: ""
-  agent_auth_file_secret_name:
-    description: GitHub Actions secret name to update when the agent auth file refreshes
-    required: false
-    default: ""
   github_token:
     description: GitHub token used by the action (defaults to the workflow token)
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -90502,16 +90502,13 @@ const hasAuthFileChanged = (initialAuthFile, currentAuthFile) => {
     return currentAuthFile.trim() !== initialAuthFile;
 };
 exports.hasAuthFileChanged = hasAuthFileChanged;
-const getAuthFileSecretUpdate = (initialAuthFile, secretName, currentAuthFile) => {
-    const trimmedSecretName = secretName?.trim();
+const getAuthFileSecretUpdate = (initialAuthFile, currentAuthFile) => {
     const trimmedAuthFile = currentAuthFile.trim();
-    if (!trimmedSecretName)
-        return undefined;
     if (!(0, exports.hasAuthFileChanged)(initialAuthFile, trimmedAuthFile))
         return undefined;
     return {
         authFile: trimmedAuthFile,
-        secretName: trimmedSecretName,
+        secretName: secrets_1.CODEX_AUTH_SECRET_NAME,
     };
 };
 exports.getAuthFileSecretUpdate = getAuthFileSecretUpdate;
@@ -90526,21 +90523,22 @@ const login = async () => {
 };
 const persistAuthFileSecret = async () => {
     const auth = (0, exports.resolveAuthStrategy)();
-    const secretName = input_1.inputs.agentAuthFileSecretName?.trim();
     if (auth.kind !== 'auth_file')
         return;
-    if (!secretName)
-        return;
     if (!fs_1.default.existsSync(CODEX_AUTH_PATH)) {
-        (0, core_1.warning)(`Cannot update ${secretName} auth file secret: ${CODEX_AUTH_PATH} does not exist.`);
+        (0, core_1.warning)(`Cannot update ${secrets_1.CODEX_AUTH_SECRET_NAME} auth file secret: ${CODEX_AUTH_PATH} does not exist.`);
         return;
     }
-    const update = (0, exports.getAuthFileSecretUpdate)(auth.authFile, secretName, fs_1.default.readFileSync(CODEX_AUTH_PATH, 'utf8'));
+    const update = (0, exports.getAuthFileSecretUpdate)(auth.authFile, fs_1.default.readFileSync(CODEX_AUTH_PATH, 'utf8'));
     if (!update)
         return;
     try {
-        await (0, secrets_1.updateRepoSecret)(update.secretName, update.authFile);
-        (0, core_1.info)(`Updated ${update.secretName} auth file secret`);
+        const target = await (0, secrets_1.updateActionsSecret)(update.secretName, update.authFile);
+        if (!target) {
+            (0, core_1.warning)(`Cannot update ${update.secretName} auth file secret: no repository or organization secret exists.`);
+            return;
+        }
+        (0, core_1.info)(`Updated ${update.secretName} ${target.kind} auth file secret`);
     }
     catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -90936,9 +90934,6 @@ exports.inputs = {
     get agentAuthFile() {
         return (0, core_1.getInput)('agent_auth_file') || undefined;
     },
-    get agentAuthFileSecretName() {
-        return (0, core_1.getInput)('agent_auth_file_secret_name') || undefined;
-    },
     get githubToken() {
         const token = (0, core_1.getInput)('github_token') || exports.inputs.workflowGithubToken;
         if (!token) {
@@ -91204,10 +91199,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateRepoSecret = exports.encryptSecret = void 0;
+exports.updateActionsSecret = exports.getActionsSecretTarget = exports.updateRepoSecret = exports.encryptSecret = exports.CODEX_AUTH_SECRET_NAME = void 0;
 const libsodium_wrappers_1 = __importDefault(__nccwpck_require__(31707));
 const github_1 = __nccwpck_require__(84903);
 const octokit_1 = __nccwpck_require__(64517);
+const error_1 = __nccwpck_require__(83294);
+exports.CODEX_AUTH_SECRET_NAME = 'CODEX_AUTH_JSON';
 const encryptSecret = async (value, publicKey) => {
     await libsodium_wrappers_1.default.ready;
     return Buffer
@@ -91228,6 +91225,66 @@ const updateRepoSecret = async (name, value) => {
     });
 };
 exports.updateRepoSecret = updateRepoSecret;
+const getActionsSecretTarget = async (name) => {
+    const { owner, repo } = github_1.context.repo;
+    const octokit = (0, octokit_1.getOctokit)();
+    try {
+        await octokit.rest.actions.getRepoSecret({ owner, repo, secret_name: name });
+        return { kind: 'repo', name };
+    }
+    catch (error) {
+        if (!(0, error_1.isNotFoundError)(error))
+            throw error;
+    }
+    const orgSecrets = await octokit.paginate(octokit.rest.actions.listRepoOrganizationSecrets, {
+        owner,
+        repo,
+        per_page: 100,
+    });
+    if (!orgSecrets.some((secret) => secret.name === name))
+        return undefined;
+    const { data } = await octokit.rest.actions.getOrgSecret({ org: owner, secret_name: name });
+    return { kind: 'org', name, visibility: data.visibility };
+};
+exports.getActionsSecretTarget = getActionsSecretTarget;
+const updateActionsSecret = async (name, value) => {
+    const target = await (0, exports.getActionsSecretTarget)(name);
+    if (!target)
+        return undefined;
+    if (target.kind === 'repo') {
+        await (0, exports.updateRepoSecret)(target.name, value);
+        return target;
+    }
+    const { owner } = github_1.context.repo;
+    const octokit = (0, octokit_1.getOctokit)();
+    const { data } = await octokit.rest.actions.getOrgPublicKey({ org: owner });
+    const encryptedValue = await (0, exports.encryptSecret)(value, data.key);
+    if (target.visibility === 'selected') {
+        const repositories = await octokit.paginate(octokit.rest.actions.listSelectedReposForOrgSecret, {
+            org: owner,
+            secret_name: target.name,
+            per_page: 100,
+        });
+        await octokit.rest.actions.createOrUpdateOrgSecret({
+            org: owner,
+            secret_name: target.name,
+            encrypted_value: encryptedValue,
+            key_id: data.key_id,
+            visibility: target.visibility,
+            selected_repository_ids: repositories.map((repository) => repository.id),
+        });
+        return target;
+    }
+    await octokit.rest.actions.createOrUpdateOrgSecret({
+        org: owner,
+        secret_name: target.name,
+        encrypted_value: encryptedValue,
+        key_id: data.key_id,
+        visibility: target.visibility,
+    });
+    return target;
+};
+exports.updateActionsSecret = updateActionsSecret;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -90533,12 +90533,8 @@ const persistAuthFileSecret = async () => {
     if (!update)
         return;
     try {
-        const target = await (0, secrets_1.updateActionsSecret)(update.secretName, update.authFile);
-        if (!target) {
-            (0, core_1.warning)(`Cannot update ${update.secretName} auth file secret: no repository or organization secret exists.`);
-            return;
-        }
-        (0, core_1.info)(`Updated ${update.secretName} ${target.kind} auth file secret`);
+        await (0, secrets_1.updateActionsSecret)(update.secretName, update.authFile);
+        (0, core_1.info)(`Updated ${update.secretName} auth file secret`);
     }
     catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -91199,7 +91195,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updateActionsSecret = exports.getActionsSecretTarget = exports.updateRepoSecret = exports.encryptSecret = exports.CODEX_AUTH_SECRET_NAME = void 0;
+exports.updateActionsSecret = exports.updateRepoSecret = exports.encryptSecret = exports.CODEX_AUTH_SECRET_NAME = void 0;
 const libsodium_wrappers_1 = __importDefault(__nccwpck_require__(31707));
 const github_1 = __nccwpck_require__(84903);
 const octokit_1 = __nccwpck_require__(64517);
@@ -91246,14 +91242,13 @@ const getActionsSecretTarget = async (name) => {
     const { data } = await octokit.rest.actions.getOrgSecret({ org: owner, secret_name: name });
     return { kind: 'org', name, visibility: data.visibility };
 };
-exports.getActionsSecretTarget = getActionsSecretTarget;
 const updateActionsSecret = async (name, value) => {
-    const target = await (0, exports.getActionsSecretTarget)(name);
+    const target = await getActionsSecretTarget(name);
     if (!target)
-        return undefined;
+        throw new Error('no repository or organization secret exists');
     if (target.kind === 'repo') {
         await (0, exports.updateRepoSecret)(target.name, value);
-        return target;
+        return;
     }
     const { owner } = github_1.context.repo;
     const octokit = (0, octokit_1.getOctokit)();
@@ -91273,7 +91268,7 @@ const updateActionsSecret = async (name, value) => {
             visibility: target.visibility,
             selected_repository_ids: repositories.map((repository) => repository.id),
         });
-        return target;
+        return;
     }
     await octokit.rest.actions.createOrUpdateOrgSecret({
         org: owner,
@@ -91282,7 +91277,6 @@ const updateActionsSecret = async (name, value) => {
         key_id: data.key_id,
         visibility: target.visibility,
     });
-    return target;
 };
 exports.updateActionsSecret = updateActionsSecret;
 

--- a/github-app/README.md
+++ b/github-app/README.md
@@ -52,6 +52,8 @@ Use org-level settings for reuse across repos, or repo-level settings for a sing
     ...
 ```
 
+Refresh writeback requires `agent_auth_file_secret_name`, `github_token`, and `permission-secrets: write`. The action writes changed auth files back as repository secrets. If the run initially reads an organization secret, writeback creates or updates a repository secret with the same name for that repository.
+
 Use a separate Codex `auth.json` for this GitHub Actions secret. Running `codex logout` with the same file revokes its refresh token and invalidates `CODEX_AUTH_JSON`.
 
 Create that separate file locally without touching your normal `~/.codex` login:

--- a/github-app/README.md
+++ b/github-app/README.md
@@ -51,7 +51,23 @@ Use org-level settings for reuse across repos, or repo-level settings for a sing
     ...
 ```
 
-Refresh writeback requires `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`, `github_token`, and `permission-secrets: write`. The action writes changed auth files back to an existing `CODEX_AUTH_JSON` repository secret, or to an existing `CODEX_AUTH_JSON` organization secret shared with the repository. Organization secret writeback requires the GitHub App to have the organization `secrets: write` permission.
+## Use Codex with ChatGPT in Actions
+
+For the default agent (`codex`), `agent_auth_file` can inject Codex's `auth.json` so the CLI can use a ChatGPT subscription. Codex can update that login file during a run, so the action saves the updated file back into `CODEX_AUTH_JSON`.
+
+During a run:
+
+- The workflow passes `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`.
+- The action writes that value to Codex's `~/.codex/auth.json`.
+- Codex may update `auth.json`.
+- If `auth.json` changed, the action saves it back to the existing `CODEX_AUTH_JSON` repository or organization secret.
+
+Requirements:
+
+- The workflow must pass `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`. GitHub does not let actions read secret values by name.
+- `CODEX_AUTH_JSON` must already exist as a repository secret or an organization secret shared with the repository.
+- `github_token` must be a GitHub App token with `permission-secrets: write`; the default `GITHUB_TOKEN` cannot update secrets.
+- Updating an organization secret requires the GitHub App to have the organization `secrets: write` permission.
 
 Use a separate Codex `auth.json` for this GitHub Actions secret. Running `codex logout` with the same file revokes its refresh token and invalidates `CODEX_AUTH_JSON`.
 

--- a/github-app/README.md
+++ b/github-app/README.md
@@ -46,13 +46,12 @@ Use org-level settings for reuse across repos, or repo-level settings for a sing
 - uses: sudden-network/agent@v1
   with:
     agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-    agent_auth_file_secret_name: CODEX_AUTH_JSON
     github_token: ${{ steps.app_token.outputs.token }}
     github_token_actor: ${{ steps.app_token.outputs.app-slug }}[bot]
     ...
 ```
 
-Refresh writeback requires `agent_auth_file_secret_name`, `github_token`, and `permission-secrets: write`. The action writes changed auth files back as repository secrets. If the run initially reads an organization secret, writeback creates or updates a repository secret with the same name for that repository.
+Refresh writeback requires `agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}`, `github_token`, and `permission-secrets: write`. The action writes changed auth files back to an existing `CODEX_AUTH_JSON` repository secret, or to an existing `CODEX_AUTH_JSON` organization secret shared with the repository. Organization secret writeback requires the GitHub App to have the organization `secrets: write` permission.
 
 Use a separate Codex `auth.json` for this GitHub Actions secret. Running `codex logout` with the same file revokes its refresh token and invalidates `CODEX_AUTH_JSON`.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sudden-agent",
   "private": true,
   "packageManager": "pnpm@11.5.3",
-  "version": "2.0.0",
+  "version": "1.14.0",
   "main": "dist/index.js",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sudden-agent",
   "private": true,
   "packageManager": "pnpm@11.5.3",
-  "version": "1.13.3",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sudden-agent",
   "private": true,
   "packageManager": "pnpm@11.5.3",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "main": "dist/index.js",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/src/agents/codex/codex.test.ts
+++ b/src/agents/codex/codex.test.ts
@@ -173,18 +173,14 @@ describe('agent codex', () => {
 
   describe('getAuthFileSecretUpdate', () => {
     it('returns update when auth file changed', () => {
-      expect(getAuthFileSecretUpdate('{ "ok": true }', ' CODEX_AUTH_JSON ', '{ "ok": false }\n')).toEqual({
+      expect(getAuthFileSecretUpdate('{ "ok": true }', '{ "ok": false }\n')).toEqual({
         authFile: '{ "ok": false }',
         secretName: 'CODEX_AUTH_JSON',
       });
     });
 
     it('skips unchanged auth file', () => {
-      expect(getAuthFileSecretUpdate('{ "ok": true }', 'CODEX_AUTH_JSON', '{ "ok": true }\n')).toBeUndefined();
-    });
-
-    it('skips missing secret name', () => {
-      expect(getAuthFileSecretUpdate('{ "ok": true }', undefined, '{ "ok": false }')).toBeUndefined();
+      expect(getAuthFileSecretUpdate('{ "ok": true }', '{ "ok": true }\n')).toBeUndefined();
     });
   });
 });

--- a/src/agents/codex/codex.ts
+++ b/src/agents/codex/codex.ts
@@ -145,12 +145,8 @@ const persistAuthFileSecret = async () => {
   if (!update) return;
 
   try {
-    const target = await updateActionsSecret(update.secretName, update.authFile);
-    if (!target) {
-      warning(`Cannot update ${update.secretName} auth file secret: no repository or organization secret exists.`);
-      return;
-    }
-    info(`Updated ${update.secretName} ${target.kind} auth file secret`);
+    await updateActionsSecret(update.secretName, update.authFile);
+    info(`Updated ${update.secretName} auth file secret`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     warning(`Failed to update ${update.secretName} auth file secret: ${message}`);

--- a/src/agents/codex/codex.ts
+++ b/src/agents/codex/codex.ts
@@ -10,7 +10,7 @@ import { isPermissionError } from '../../github/error';
 import { info, warning } from '@actions/core';
 import { BootstrapOptions, BootstrapResult } from '../../agent';
 import type { McpServerConfig } from '../../mcp';
-import { updateRepoSecret } from '../../github/secrets';
+import { CODEX_AUTH_SECRET_NAME, updateActionsSecret } from '../../github/secrets';
 
 type AuthStrategy =
   | { kind: 'api_key'; apiKey: string }
@@ -104,18 +104,15 @@ export const hasAuthFileChanged = (initialAuthFile: string, currentAuthFile: str
 
 export const getAuthFileSecretUpdate = (
   initialAuthFile: string,
-  secretName: string | undefined,
   currentAuthFile: string,
 ): { authFile: string; secretName: string } | undefined => {
-  const trimmedSecretName = secretName?.trim();
   const trimmedAuthFile = currentAuthFile.trim();
 
-  if (!trimmedSecretName) return undefined;
   if (!hasAuthFileChanged(initialAuthFile, trimmedAuthFile)) return undefined;
 
   return {
     authFile: trimmedAuthFile,
-    secretName: trimmedSecretName,
+    secretName: CODEX_AUTH_SECRET_NAME,
   };
 };
 
@@ -133,26 +130,27 @@ const login = async () => {
 
 const persistAuthFileSecret = async () => {
   const auth = resolveAuthStrategy();
-  const secretName = inputs.agentAuthFileSecretName?.trim();
 
   if (auth.kind !== 'auth_file') return;
-  if (!secretName) return;
   if (!fs.existsSync(CODEX_AUTH_PATH)) {
-    warning(`Cannot update ${secretName} auth file secret: ${CODEX_AUTH_PATH} does not exist.`);
+    warning(`Cannot update ${CODEX_AUTH_SECRET_NAME} auth file secret: ${CODEX_AUTH_PATH} does not exist.`);
     return;
   }
 
   const update = getAuthFileSecretUpdate(
     auth.authFile,
-    secretName,
     fs.readFileSync(CODEX_AUTH_PATH, 'utf8'),
   );
 
   if (!update) return;
 
   try {
-    await updateRepoSecret(update.secretName, update.authFile);
-    info(`Updated ${update.secretName} auth file secret`);
+    const target = await updateActionsSecret(update.secretName, update.authFile);
+    if (!target) {
+      warning(`Cannot update ${update.secretName} auth file secret: no repository or organization secret exists.`);
+      return;
+    }
+    info(`Updated ${update.secretName} ${target.kind} auth file secret`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     warning(`Failed to update ${update.secretName} auth file secret: ${message}`);

--- a/src/github/input.ts
+++ b/src/github/input.ts
@@ -7,9 +7,6 @@ export const inputs = {
   get agentAuthFile(): string | undefined {
     return getInput('agent_auth_file') || undefined;
   },
-  get agentAuthFileSecretName(): string | undefined {
-    return getInput('agent_auth_file_secret_name') || undefined;
-  },
   get githubToken(): string {
     const token = getInput('github_token') || inputs.workflowGithubToken;
 

--- a/src/github/secrets.test.ts
+++ b/src/github/secrets.test.ts
@@ -198,10 +198,12 @@ describe('github secrets', () => {
       });
     });
 
-    it('skips missing repo and org secrets', async () => {
+    it('throws when repo and org secrets are missing', async () => {
       getRepoSecretMock.mockRejectedValue({ status: 404 });
 
-      await expect(updateActionsSecret('CODEX_AUTH_JSON', 'secret-value')).resolves.toBeUndefined();
+      await expect(updateActionsSecret('CODEX_AUTH_JSON', 'secret-value')).rejects.toThrow(
+        'no repository or organization secret exists',
+      );
 
       expect(createOrUpdateRepoSecretMock).not.toHaveBeenCalled();
       expect(createOrUpdateOrgSecretMock).not.toHaveBeenCalled();

--- a/src/github/secrets.test.ts
+++ b/src/github/secrets.test.ts
@@ -11,16 +11,50 @@ const getRepoPublicKeyMock = jest.fn().mockResolvedValue({
     key_id: 'key-id',
   },
 });
+const getOrgPublicKeyMock = jest.fn().mockResolvedValue({
+  data: {
+    key: Buffer.from('org-public-key').toString('base64'),
+    key_id: 'org-key-id',
+  },
+});
+const getRepoSecretMock = jest.fn().mockResolvedValue({ data: { name: 'CODEX_AUTH_JSON' } });
+const listRepoOrganizationSecretsMock = jest.fn().mockResolvedValue({
+  data: {
+    secrets: [],
+  },
+});
+const getOrgSecretMock = jest.fn().mockResolvedValue({
+  data: {
+    name: 'CODEX_AUTH_JSON',
+    visibility: 'private',
+  },
+});
+const listSelectedReposForOrgSecretMock = jest.fn().mockResolvedValue({
+  data: {
+    repositories: [],
+  },
+});
 const createOrUpdateRepoSecretMock = jest.fn().mockResolvedValue(undefined);
+const createOrUpdateOrgSecretMock = jest.fn().mockResolvedValue(undefined);
+const paginateMock = jest.fn((endpoint, params) => endpoint(params).then(({ data }: {
+  data: { repositories?: { id: number }[]; secrets?: { name: string }[] };
+}) => data.repositories ?? data.secrets ?? []));
 
 jest.mock('@actions/github', () => ({ context: contextMock }));
 
 jest.mock('./octokit', () => ({
   getOctokit: () => ({
+    paginate: paginateMock,
     rest: {
       actions: {
         getRepoPublicKey: getRepoPublicKeyMock,
+        getOrgPublicKey: getOrgPublicKeyMock,
+        getRepoSecret: getRepoSecretMock,
+        getOrgSecret: getOrgSecretMock,
+        listRepoOrganizationSecrets: listRepoOrganizationSecretsMock,
+        listSelectedReposForOrgSecret: listSelectedReposForOrgSecretMock,
         createOrUpdateRepoSecret: createOrUpdateRepoSecretMock,
+        createOrUpdateOrgSecret: createOrUpdateOrgSecretMock,
       },
     },
   }),
@@ -35,7 +69,7 @@ jest.mock('libsodium-wrappers', () => ({
 }));
 
 import sodium from 'libsodium-wrappers';
-import { encryptSecret, updateRepoSecret } from './secrets';
+import { encryptSecret, updateActionsSecret, updateRepoSecret } from './secrets';
 
 const cryptoBoxSealMock = jest.mocked(sodium.crypto_box_seal);
 
@@ -43,7 +77,23 @@ describe('github secrets', () => {
   afterEach(() => {
     cryptoBoxSealMock.mockClear();
     getRepoPublicKeyMock.mockClear();
+    getOrgPublicKeyMock.mockClear();
+    getRepoSecretMock.mockClear();
+    getRepoSecretMock.mockResolvedValue({ data: { name: 'CODEX_AUTH_JSON' } });
+    listRepoOrganizationSecretsMock.mockClear();
+    listRepoOrganizationSecretsMock.mockResolvedValue({ data: { secrets: [] } });
+    getOrgSecretMock.mockClear();
+    getOrgSecretMock.mockResolvedValue({
+      data: {
+        name: 'CODEX_AUTH_JSON',
+        visibility: 'private',
+      },
+    });
+    listSelectedReposForOrgSecretMock.mockClear();
+    listSelectedReposForOrgSecretMock.mockResolvedValue({ data: { repositories: [] } });
     createOrUpdateRepoSecretMock.mockClear();
+    createOrUpdateOrgSecretMock.mockClear();
+    paginateMock.mockClear();
   });
 
   describe('encryptSecret', () => {
@@ -71,6 +121,90 @@ describe('github secrets', () => {
         encrypted_value: Buffer.from([1, 2, 3]).toString('base64'),
         key_id: 'key-id',
       });
+    });
+  });
+
+  describe('updateActionsSecret', () => {
+    it('updates an existing repo secret', async () => {
+      await updateActionsSecret('CODEX_AUTH_JSON', 'secret-value');
+
+      expect(getRepoSecretMock).toHaveBeenCalledWith({
+        owner: 'octo',
+        repo: 'agent',
+        secret_name: 'CODEX_AUTH_JSON',
+      });
+      expect(createOrUpdateRepoSecretMock).toHaveBeenCalledWith({
+        owner: 'octo',
+        repo: 'agent',
+        secret_name: 'CODEX_AUTH_JSON',
+        encrypted_value: Buffer.from([1, 2, 3]).toString('base64'),
+        key_id: 'key-id',
+      });
+      expect(createOrUpdateOrgSecretMock).not.toHaveBeenCalled();
+    });
+
+    it('updates an org secret shared with the repo', async () => {
+      getRepoSecretMock.mockRejectedValue({ status: 404 });
+      listRepoOrganizationSecretsMock.mockResolvedValue({
+        data: {
+          secrets: [{ name: 'CODEX_AUTH_JSON' }],
+        },
+      });
+
+      await updateActionsSecret('CODEX_AUTH_JSON', 'secret-value');
+
+      expect(createOrUpdateRepoSecretMock).not.toHaveBeenCalled();
+      expect(getOrgSecretMock).toHaveBeenCalledWith({
+        org: 'octo',
+        secret_name: 'CODEX_AUTH_JSON',
+      });
+      expect(createOrUpdateOrgSecretMock).toHaveBeenCalledWith({
+        org: 'octo',
+        secret_name: 'CODEX_AUTH_JSON',
+        encrypted_value: Buffer.from([1, 2, 3]).toString('base64'),
+        key_id: 'org-key-id',
+        visibility: 'private',
+      });
+    });
+
+    it('preserves selected repositories for selected org secrets', async () => {
+      getRepoSecretMock.mockRejectedValue({ status: 404 });
+      listRepoOrganizationSecretsMock.mockResolvedValue({
+        data: {
+          secrets: [{ name: 'CODEX_AUTH_JSON' }],
+        },
+      });
+      getOrgSecretMock.mockResolvedValue({
+        data: {
+          name: 'CODEX_AUTH_JSON',
+          visibility: 'selected',
+        },
+      });
+      listSelectedReposForOrgSecretMock.mockResolvedValue({
+        data: {
+          repositories: [{ id: 123 }, { id: 456 }],
+        },
+      });
+
+      await updateActionsSecret('CODEX_AUTH_JSON', 'secret-value');
+
+      expect(createOrUpdateOrgSecretMock).toHaveBeenCalledWith({
+        org: 'octo',
+        secret_name: 'CODEX_AUTH_JSON',
+        encrypted_value: Buffer.from([1, 2, 3]).toString('base64'),
+        key_id: 'org-key-id',
+        visibility: 'selected',
+        selected_repository_ids: [123, 456],
+      });
+    });
+
+    it('skips missing repo and org secrets', async () => {
+      getRepoSecretMock.mockRejectedValue({ status: 404 });
+
+      await expect(updateActionsSecret('CODEX_AUTH_JSON', 'secret-value')).resolves.toBeUndefined();
+
+      expect(createOrUpdateRepoSecretMock).not.toHaveBeenCalled();
+      expect(createOrUpdateOrgSecretMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/github/secrets.ts
+++ b/src/github/secrets.ts
@@ -1,6 +1,15 @@
 import sodium from 'libsodium-wrappers';
 import { context } from '@actions/github';
 import { getOctokit } from './octokit';
+import { isNotFoundError } from './error';
+
+export const CODEX_AUTH_SECRET_NAME = 'CODEX_AUTH_JSON';
+
+type OrgSecretVisibility = 'all' | 'private' | 'selected';
+
+type ActionsSecretTarget =
+  | { kind: 'repo'; name: string }
+  | { kind: 'org'; name: string; visibility: OrgSecretVisibility };
 
 export const encryptSecret = async (value: string, publicKey: string): Promise<string> => {
   await sodium.ready;
@@ -22,4 +31,71 @@ export const updateRepoSecret = async (name: string, value: string): Promise<voi
     encrypted_value: await encryptSecret(value, data.key),
     key_id: data.key_id,
   });
+};
+
+export const getActionsSecretTarget = async (name: string): Promise<ActionsSecretTarget | undefined> => {
+  const { owner, repo } = context.repo;
+  const octokit = getOctokit();
+
+  try {
+    await octokit.rest.actions.getRepoSecret({ owner, repo, secret_name: name });
+    return { kind: 'repo', name };
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
+  }
+
+  const orgSecrets = await octokit.paginate(octokit.rest.actions.listRepoOrganizationSecrets, {
+    owner,
+    repo,
+    per_page: 100,
+  });
+
+  if (!orgSecrets.some((secret) => secret.name === name)) return undefined;
+
+  const { data } = await octokit.rest.actions.getOrgSecret({ org: owner, secret_name: name });
+  return { kind: 'org', name, visibility: data.visibility };
+};
+
+export const updateActionsSecret = async (
+  name: string,
+  value: string,
+): Promise<ActionsSecretTarget | undefined> => {
+  const target = await getActionsSecretTarget(name);
+  if (!target) return undefined;
+  if (target.kind === 'repo') {
+    await updateRepoSecret(target.name, value);
+    return target;
+  }
+
+  const { owner } = context.repo;
+  const octokit = getOctokit();
+  const { data } = await octokit.rest.actions.getOrgPublicKey({ org: owner });
+  const encryptedValue = await encryptSecret(value, data.key);
+
+  if (target.visibility === 'selected') {
+    const repositories = await octokit.paginate(octokit.rest.actions.listSelectedReposForOrgSecret, {
+      org: owner,
+      secret_name: target.name,
+      per_page: 100,
+    });
+
+    await octokit.rest.actions.createOrUpdateOrgSecret({
+      org: owner,
+      secret_name: target.name,
+      encrypted_value: encryptedValue,
+      key_id: data.key_id,
+      visibility: target.visibility,
+      selected_repository_ids: repositories.map((repository) => repository.id),
+    });
+    return target;
+  }
+
+  await octokit.rest.actions.createOrUpdateOrgSecret({
+    org: owner,
+    secret_name: target.name,
+    encrypted_value: encryptedValue,
+    key_id: data.key_id,
+    visibility: target.visibility,
+  });
+  return target;
 };

--- a/src/github/secrets.ts
+++ b/src/github/secrets.ts
@@ -5,12 +5,6 @@ import { isNotFoundError } from './error';
 
 export const CODEX_AUTH_SECRET_NAME = 'CODEX_AUTH_JSON';
 
-type OrgSecretVisibility = 'all' | 'private' | 'selected';
-
-type ActionsSecretTarget =
-  | { kind: 'repo'; name: string }
-  | { kind: 'org'; name: string; visibility: OrgSecretVisibility };
-
 export const encryptSecret = async (value: string, publicKey: string): Promise<string> => {
   await sodium.ready;
 
@@ -33,7 +27,13 @@ export const updateRepoSecret = async (name: string, value: string): Promise<voi
   });
 };
 
-export const getActionsSecretTarget = async (name: string): Promise<ActionsSecretTarget | undefined> => {
+const getActionsSecretTarget = async (
+  name: string,
+): Promise<
+  | { kind: 'repo'; name: string }
+  | { kind: 'org'; name: string; visibility: 'all' | 'private' | 'selected' }
+  | undefined
+> => {
   const { owner, repo } = context.repo;
   const octokit = getOctokit();
 
@@ -59,12 +59,12 @@ export const getActionsSecretTarget = async (name: string): Promise<ActionsSecre
 export const updateActionsSecret = async (
   name: string,
   value: string,
-): Promise<ActionsSecretTarget | undefined> => {
+): Promise<void> => {
   const target = await getActionsSecretTarget(name);
-  if (!target) return undefined;
+  if (!target) throw new Error('no repository or organization secret exists');
   if (target.kind === 'repo') {
     await updateRepoSecret(target.name, value);
-    return target;
+    return;
   }
 
   const { owner } = context.repo;
@@ -87,7 +87,7 @@ export const updateActionsSecret = async (
       visibility: target.visibility,
       selected_repository_ids: repositories.map((repository) => repository.id),
     });
-    return target;
+    return;
   }
 
   await octokit.rest.actions.createOrUpdateOrgSecret({
@@ -97,5 +97,4 @@ export const updateActionsSecret = async (
     key_id: data.key_id,
     visibility: target.visibility,
   });
-  return target;
 };


### PR DESCRIPTION
## Summary
- always save updated Codex login files back to CODEX_AUTH_JSON
- update an existing repository secret, or an existing organization secret shared with the repository
- document the ChatGPT subscription setup in the GitHub App guide
- bump to 1.14.0 because the changes are backward-compatible

## Tests
- pnpm build
- pnpm test
- git diff --check