### PR TITLE
Upgrade Codex to GPT-5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This makes iterative work practical: the agent remembers what it already covered
 | `agent_auth_file` | no | Agent auth file content (agent-specific). |
 | `github_token` | no | GitHub token used by the action (defaults to the workflow token). |
 | `github_token_actor` | no | Actor login for `github_token` when using a non-workflow token (e.g. `sudden-agent[bot]`). |
-| `model` | no | Agent model override (for Codex, append reasoning effort and service tier with `/`, e.g. `gpt-5.5/xhigh/fast`). |
+| `model` | no | Codex `model[/reasoning][/speed]` override. Default: `gpt-5.6-sol`. |
 | `prompt` | no | Additional instructions for the agent. |
 | `resume` | no | Enable session persistence. Default: `false`. |
 | `sudo` | no | Disable sandbox; allow write + network access. Default: `false`. |
@@ -43,6 +43,16 @@ This makes iterative work practical: the agent remembers what it already covered
 
 - Use `prompt` for per-workflow instructions.
 - If you want repo-level instructions, add an [AGENTS.md](https://agents.md/) file and run this action after `actions/checkout` so the agent can read it.
+
+### Codex model
+
+The `model` input accepts `model[/reasoning][/speed]`:
+
+- Models: `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, or `gpt-5.6-luna`. The default is the flagship `gpt-5.6-sol`.
+- Reasoning: `low`, `medium`, `high`, `xhigh`, `max`, or `ultra`, when supported by the model. Codex labels `low` as Light and `xhigh` as Extra High in graphical clients.
+- Speed: `standard` or `fast`. Standard is the default, so omit the last segment unless you want Fast mode.
+
+For example, `gpt-5.6-sol/xhigh/fast` passes `--model=gpt-5.6-sol`, `model_reasoning_effort=xhigh`, and `service_tier=fast` to the Codex CLI. `gpt-5.6-sol/xhigh` and `gpt-5.6-sol/xhigh/standard` both use Standard speed.
 
 ## Authentication
 

--- a/action.yml
+++ b/action.yml
@@ -32,9 +32,9 @@ inputs:
     required: false
     default: codex
   model:
-    description: Agent model override (for Codex, append reasoning effort and service tier with /, e.g. gpt-5.5/xhigh/fast)
+    description: Codex model[/reasoning][/speed] (speed is standard or fast)
     required: false
-    default: ""
+    default: gpt-5.6-sol
   prompt:
     description: Optional extra instructions for the agent
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -90417,7 +90417,7 @@ const input_1 = __nccwpck_require__(55404);
 const error_1 = __nccwpck_require__(83294);
 const core_1 = __nccwpck_require__(16966);
 const secrets_1 = __nccwpck_require__(68917);
-const CODEX_VERSION = '0.136.0';
+const CODEX_VERSION = '0.145.0';
 const CODEX_DIR = path_1.default.join(os_1.default.homedir(), '.codex');
 const CODEX_CONFIG_PATH = path_1.default.join(CODEX_DIR, 'config.toml');
 const CODEX_AUTH_PATH = path_1.default.join(CODEX_DIR, 'auth.json');
@@ -90551,7 +90551,7 @@ const parseModelInput = (value) => {
     return {
         model: model || undefined,
         reasoningEffort: reasoningEffort || undefined,
-        serviceTier: serviceTier || undefined,
+        serviceTier: serviceTier && serviceTier !== 'standard' ? serviceTier : undefined,
     };
 };
 exports.parseModelInput = parseModelInput;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sudden-agent",
   "private": true,
   "packageManager": "pnpm@11.5.3",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "dist/index.js",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/scripts/bootstrap-codex-auth.sh
+++ b/scripts/bootstrap-codex-auth.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CODEX_VERSION="0.136.0"
+CODEX_VERSION="0.145.0"
 CODEX_HOME_DIR="$(mktemp -d)"
 
 cleanup() {

--- a/src/agents/codex/codex.run.test.ts
+++ b/src/agents/codex/codex.run.test.ts
@@ -45,15 +45,28 @@ describe('codex run', () => {
   });
 
   it('passes model config', async () => {
-    inputsMock.model = 'gpt-5.5/xhigh/fast';
+    inputsMock.model = 'gpt-5.6-sol/ultra/fast';
 
     await run('prompt');
 
     const args = runCommandMock.mock.calls[0][1];
     expect(args).toEqual(expect.arrayContaining([
-      '--model=gpt-5.5',
-      '--config=model_reasoning_effort=xhigh',
+      '--model=gpt-5.6-sol',
+      '--config=model_reasoning_effort=ultra',
       '--config=service_tier=fast',
     ]));
+  });
+
+  it('omits the standard service tier override', async () => {
+    inputsMock.model = 'gpt-5.6-sol/medium/standard';
+
+    await run('prompt');
+
+    const args = runCommandMock.mock.calls[0][1];
+    expect(args).toEqual(expect.arrayContaining([
+      '--model=gpt-5.6-sol',
+      '--config=model_reasoning_effort=medium',
+    ]));
+    expect(args).not.toContain('--config=service_tier=standard');
   });
 });

--- a/src/agents/codex/codex.test.ts
+++ b/src/agents/codex/codex.test.ts
@@ -53,10 +53,18 @@ describe('agent codex', () => {
     });
 
     it('parses model, reasoning effort, and service tier', () => {
-      expect(parseModelInput('gpt-5.5/xhigh/fast')).toEqual({
-        model: 'gpt-5.5',
-        reasoningEffort: 'xhigh',
+      expect(parseModelInput('gpt-5.6-sol/ultra/fast')).toEqual({
+        model: 'gpt-5.6-sol',
+        reasoningEffort: 'ultra',
         serviceTier: 'fast',
+      });
+    });
+
+    it('uses the standard service tier by default', () => {
+      expect(parseModelInput('gpt-5.6-sol/xhigh/standard')).toEqual({
+        model: 'gpt-5.6-sol',
+        reasoningEffort: 'xhigh',
+        serviceTier: undefined,
       });
     });
 
@@ -82,10 +90,10 @@ describe('agent codex', () => {
     });
 
     it('throws when service tier skips reasoning effort', () => {
-      expect(() => parseModelInput('gpt-5.5//fast')).toThrow(
+      expect(() => parseModelInput('gpt-5.6-sol//fast')).toThrow(
         'Invalid model input: service tier requires reasoning effort.',
       );
-      expect(() => parseModelInput('gpt-5.5/ /fast')).toThrow(
+      expect(() => parseModelInput('gpt-5.6-sol/ /fast')).toThrow(
         'Invalid model input: service tier requires reasoning effort.',
       );
     });

--- a/src/agents/codex/codex.ts
+++ b/src/agents/codex/codex.ts
@@ -16,7 +16,7 @@ type AuthStrategy =
   | { kind: 'api_key'; apiKey: string }
   | { kind: 'auth_file'; authFile: string };
 
-const CODEX_VERSION = '0.136.0';
+const CODEX_VERSION = '0.145.0';
 const CODEX_DIR = path.join(os.homedir(), '.codex');
 const CODEX_CONFIG_PATH = path.join(CODEX_DIR, 'config.toml');
 const CODEX_AUTH_PATH = path.join(CODEX_DIR, 'auth.json');
@@ -164,7 +164,7 @@ export const parseModelInput = (value: string | undefined) => {
   return {
     model: model || undefined,
     reasoningEffort: reasoningEffort || undefined,
-    serviceTier: serviceTier || undefined,
+    serviceTier: serviceTier && serviceTier !== 'standard' ? serviceTier : undefined,
   };
 };
 


### PR DESCRIPTION
## Summary
- pin Codex CLI 0.145.0
- default to flagship gpt-5.6-sol
- support model/reasoning/speed syntax, including ultra and standard/fast
- document current models and CLI mappings
- rebuild dist and bump to 1.15.0

## Testing
- pnpm test --runInBand
- pnpm typecheck
- pnpm build

## Follow-up
- keep repository workflows on gpt-5.5 in this PR
- update workflows to gpt-5.6-sol/xhigh/fast in a second PR after merge