### PR TITLE
Use GPT-5.6 Sol in workflows

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.5/xhigh/fast
+          model: gpt-5.6-sol/xhigh/fast
           resume: true
           prompt: |
             Goals:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.5/xhigh/fast
+          model: gpt-5.6-sol/xhigh/fast
           prompt: |
             Goal: on every push to main, move v{major} to the current commit. If package.json version changed, create v{version} and a GitHub release for it.
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./
         with:
           agent_auth_file: ${{ secrets.CODEX_AUTH_JSON }}
-          model: gpt-5.5/xhigh/fast
+          model: gpt-5.6-sol/xhigh/fast
           resume: true
           prompt: |
             Goal: keep the root package.json version aligned with the impact of changes in this repo.


### PR DESCRIPTION
## Summary

- update code review to gpt-5.6-sol/xhigh/fast
- update version bump to gpt-5.6-sol/xhigh/fast
- update tag and release to gpt-5.6-sol/xhigh/fast

Follow-up to #117.